### PR TITLE
Guild Logging, Presence, and Tip Command

### DIFF
--- a/auth.json.example
+++ b/auth.json.example
@@ -11,5 +11,6 @@
 	"feedbackChannel": "",
 	"tipChannel": "",
 	"testChannel": "",
+	"guildLogChannel": "",
 	"prefix": "!"
 }

--- a/bot.js
+++ b/bot.js
@@ -11,8 +11,10 @@ const glob = require("glob");
 const DDClient = require("./structures/DDClient.struct");
 
 const { Orders, Blacklist, WorkerInfo } = require("./sequelize");
-const { token, ticketChannel, prefix, testChannel } = require("./auth.json");
+const { token, ticketChannel, prefix, testChannel, guildLogChannel } = require("./auth.json");
 const { generateTicket, timeout } = require("./helpers");
+
+const DDEmbed = require("structures/DDEmbed.struct");
 
 const test = TEST ? require("./test.js") : undefined;
 
@@ -91,6 +93,17 @@ client.on("message", async message => {
 		console.log(e);
 		message.reply(`An error occurred!\n\`\`\`\n${e.toString()}\n\`\`\``);
 	}
+});
+
+client.on("guildCreate", guild => {
+	const embed =
+		new DDEmbed(client)
+			.setStyle("colorful")
+			.setTitle("New Guild")
+			.setDescription("New Guild Joined!")
+			.addField("Guild Name", `${guild.name} (${guild.id})`);
+
+	client.channels.get(guildLogChannel).send(embed);
 });
 
 client.login(token);

--- a/bot.js
+++ b/bot.js
@@ -62,6 +62,14 @@ client.once("ready", () => {
 	Orders.sync();
 	Blacklist.sync();
 	WorkerInfo.sync();
+
+	// Activities  
+	const activitiesList = ["Cooking Donuts...", "Donuts!", "Cookin' Donuts", "d!order Donuts", "<3 Donuts", "with Donuts"];
+
+	setInterval(() => {
+		let index = Math.floor((Math.random() * (activitiesList.length - 1)) + 1);
+		client.user.setActivity(activitiesList[index]);
+	}, 300000);
 });
 
 client.on("message", async message => {

--- a/bot.js
+++ b/bot.js
@@ -106,5 +106,16 @@ client.on("guildCreate", guild => {
 	client.channels.get(guildLogChannel).send(embed);
 });
 
+client.on("guildDelete", guild => {
+	const embed =
+		new DDEmbed(client)
+			.setStyle("colorful")
+			.setTitle("Left Guild")
+			.setDescription("Left a Guild!")
+			.addField("Guild Name", `${guild.name} (${guild.id})`);
+
+	client.channels.get(guildLogChannel).send(embed);
+});
+
 client.login(token);
 

--- a/bot.js
+++ b/bot.js
@@ -65,7 +65,7 @@ client.once("ready", () => {
 	Blacklist.sync();
 	WorkerInfo.sync();
 
-	// Activities  
+	// Activities
 	const activitiesList = ["Cooking Donuts...", "Donuts!", "Cookin' Donuts", "d!order Donuts", "<3 Donuts", "with Donuts"];
 
 	setInterval(() => {

--- a/commands/public/order.cmd.js
+++ b/commands/public/order.cmd.js
@@ -39,7 +39,7 @@ module.exports =
 				url: null,
 				ticketMessageID: null
 			}).catch(console.log);
-	
+
 			const embed =
 				new DDEmbed(client)
 					.setStyle("white")

--- a/commands/public/tip.cmd.js
+++ b/commands/public/tip.cmd.js
@@ -1,0 +1,28 @@
+const DDEmbed = require("../../structures/DDEmbed.struct");
+const DDCommand = require("../../structures/DDCommand.struct");
+
+const { tipChannel } = require("../../auth.json");
+
+const { everyone } = require("../../permissions");
+
+module.exports =
+	new DDCommand()
+		.setName("tip")
+		.setDescription("Give virtual tips.")
+		.setPermissions(everyone)
+		.setFunction(async(message, args, client) => {
+			if (!args[0]) return message.channel.send(":x: Make sure to include what you tipped!");
+
+			if (isNaN(args[0])) return message.channel.send(`:x: ${args[0]} is not a number!`);
+
+			const embed =
+				new DDEmbed(client)
+					.setStyle("white")
+					.setTitle(`New tip from ${message.author.tag} (${message.author.id})`)
+					.setDescription(`$${args[0]}`)
+					.setThumbnail("https://images.emojiterra.com/twitter/512px/1f4b0.png");
+
+			client.channels.get(tipChannel).send(embed);
+
+			return message.reply("Thank you for tipping us!");
+		});


### PR DESCRIPTION
# Guild Logging, Presence, and Tip Command
## Additions
- Guild logging for guilds joined and guilds left. (#28)
- Added `guildLogChannel` as a entry in the auth.json.
- Presence for the bot including `["Cooking Donuts...", "Donuts!", "Cookin' Donuts", "d!order Donuts", "<3 Donuts", "with Donuts"]` (#23)
- Tip Command (#3)

## Fixed
- Fixed trailing spaces in order command.